### PR TITLE
Added AsyncResultExtractors and specs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: scala
+scala:
+  - 2.11.7
+
+script:
+  - sbt +clean coverage +test coverageReport
+  - sbt coverageAggregate
+after_success:
+  - sbt coveralls
+
+  # Tricks to avoid unnecessary cache updates
+  - find $HOME/.sbt -name "*.lock" | xargs rm
+  - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
+
+# These directories are cached to S3 at the end of the build
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt/boot/
+

--- a/build.sbt
+++ b/build.sbt
@@ -1,24 +1,48 @@
-name := "play-test-ops"
 organization := "me.jeffmay"
+organizationName := "Jeff May"
 
-lazy val commonSettings = Seq(
-  scalaVersion := "2.11.7",
+// set the scala version on the root project
+scalaVersion := "2.11.7"
+
+// don't publish the surrounding multi-project root
+publish := {}
+
+val commonSettings = Seq(
+
   scalacOptions ++= Seq(
     "-encoding", "UTF-8",
     "-deprecation:false",
     "-feature",
     "-Xfatal-warnings",
     "-Ywarn-dead-code"
-  )
+  ),
+
+  resolvers ++= Seq(
+    "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
+  ),
+
+  ivyScala := ivyScala.value map { _.copy(overrideScalaVersion = true) },
+
+  // don't publish the test code
+  publishArtifact in Test := false,
+
+  // disable compilation of ScalaDocs, since this always breaks on links
+  sources in(Compile, doc) := Seq.empty,
+
+  // disable publishing empty ScalaDocs
+  publishArtifact in (Compile, packageDoc) := false,
+
+  licenses += ("Apache-2.0", url("http://opensource.org/licenses/apache-2.0"))
 )
 
 lazy val `play23-test-ops` = (project in file("play23"))
   .settings(commonSettings)
   .settings(
+    name := "play-test-ops",
+    version := "0.1.0",
     libraryDependencies ++= Seq(
       "com.typesafe.play" %% "play" % "2.3.10",
       "com.typesafe.play" %% "play-test" % "2.3.10" % "test",
       "org.scalatest" %% "scalatest" % "3.0.0-RC4" % "test"
     )
   )
-

--- a/play23/src/main/scala/play/api/test/ops/AsyncResultExtractors.scala
+++ b/play23/src/main/scala/play/api/test/ops/AsyncResultExtractors.scala
@@ -1,0 +1,123 @@
+package play.api.test.ops
+
+import play.api.http.HeaderNames._
+import play.api.http.Status._
+import play.api.libs.iteratee.Iteratee
+import play.api.libs.json.{JsValue, Json}
+import play.api.mvc._
+import play.twirl.api.Content
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+  * Similar to play.api.test.ResultExtractors except that it is designed to work better
+  * for org.scalatest.AsyncSuite in ScalaTest 3.0.
+  *
+  * All methods return either the expected value or a [[Future]] and does not perform
+  * any awaits or timeouts. This improves the total time spent on tests and cuts
+  * down on processor usage.
+  */
+trait AsyncResultExtractors {
+
+  /**
+    * Extracts the Content-Type of this Content value.
+    */
+  def contentType(of: Content): String = of.contentType
+
+  /**
+    * Extracts the content as String.
+    */
+  def contentAsString(of: Content): String = of.body
+
+  /**
+    * Extracts the content as bytes.
+    */
+  def contentAsBytes(of: Content): Array[Byte] = of.body.getBytes
+
+  /**
+    * Extracts the content as Json.
+    */
+  def contentAsJson(of: Content): JsValue = Json.parse(of.body)
+
+  /**
+    * Extracts the Content-Type of this Result value.
+    */
+  def contentType(result: Result): Option[String] = {
+    header(CONTENT_TYPE, result).map(_.split(";").take(1).mkString.trim)
+  }
+
+  /**
+    * Extracts the Charset of this Result value.
+    */
+  def charset(result: Result): Option[String] = header(CONTENT_TYPE, result) match {
+    case Some(s) if s.contains("charset=") => Some(s.split("; charset=").drop(1).mkString.trim)
+    case _ => None
+  }
+
+  /**
+    * Extracts the content as String.
+    */
+  def contentAsString(result: Result)(implicit ec: ExecutionContext): Future[String] = {
+    contentAsBytes(result).map(new String(_, charset(result).getOrElse("utf-8")))
+  }
+
+  /**
+    * Extracts the content as bytes.
+    */
+  def contentAsBytes(result: Result): Future[Array[Byte]] = {
+    val eBytes = result.header.headers.get(TRANSFER_ENCODING) match {
+      case Some("chunked") => result.body &> Results.dechunk
+      case _ => result.body
+    }
+    eBytes |>>> Iteratee.consume[Array[Byte]]()
+  }
+
+  /**
+    * Extracts the content as Json.
+    */
+  def contentAsJson(result: Result)(implicit ec: ExecutionContext): Future[JsValue] = {
+    contentAsString(result).map(Json.parse)
+  }
+
+  /**
+    * Extracts the Status code of this Result value.
+    */
+  def status(result: Result): Int = result.header.status
+
+  /**
+    * Extracts the Cookies of this Result value.
+    */
+  def cookies(result: Result): Cookies = Cookies(header(SET_COOKIE, result))
+
+  /**
+    * Extracts the Flash values of this Result value.
+    */
+  def flash(result: Result): Flash = Flash.decodeFromCookie(cookies(result).get(Flash.COOKIE_NAME))
+
+  /**
+    * Extracts the Session of this Result value.
+    * Extracts the Session from this Result value.
+    */
+  def session(result: Result): Session = Session.decodeFromCookie(cookies(result).get(Session.COOKIE_NAME))
+
+  /**
+    * Extracts the Location header of this Result value if this Result is a Redirect.
+    */
+  def redirectLocation(result: Result): Option[String] = result.header match {
+    case ResponseHeader(FOUND, headers) => headers.get(LOCATION)
+    case ResponseHeader(SEE_OTHER, headers) => headers.get(LOCATION)
+    case ResponseHeader(TEMPORARY_REDIRECT, headers) => headers.get(LOCATION)
+    case ResponseHeader(MOVED_PERMANENTLY, headers) => headers.get(LOCATION)
+    case ResponseHeader(_, _) => None
+  }
+
+  /**
+    * Extracts an Header value of this Result value.
+    */
+  def header(header: String, result: Result): Option[String] = result.header.headers.get(header)
+
+  /**
+    * Extracts all Headers of this Result value.
+    */
+  def headers(result: Result): Map[String, String] = result.header.headers
+}

--- a/play23/src/test/scala/play/api/test/ops/AsyncResultExtractorsSpec.scala
+++ b/play23/src/test/scala/play/api/test/ops/AsyncResultExtractorsSpec.scala
@@ -1,0 +1,271 @@
+package play.api.test.ops
+
+import org.scalatest.{Args, AsyncFreeSpec, Status => TestStatus}
+import play.api.{Application, Play}
+import play.api.http.{ContentTypes, MimeTypes, Status}
+import play.api.libs.json.{JsValue, Json}
+import play.api.mvc._
+import play.api.test._
+
+class AsyncResultExtractorsSpec extends AsyncFreeSpec with AsyncResultExtractors
+  with EssentialActionCaller
+  with Writeables {
+
+  implicit lazy val app: Application = FakeApplication()
+
+  protected override def runTests(testName: Option[String], args: Args): TestStatus = {
+    // Use a single application for all the suites
+    Play.start(app)
+    val resultStatus = super.runTests(testName, args)
+    resultStatus.whenCompleted(_ => Play.stop())
+    resultStatus
+  }
+
+  class TestEchoController extends Controller {
+
+    def echoTextBody: EssentialAction = Action { request =>
+      Ok(request.body.asText.getOrElse("Missing body"))
+    }
+
+    def echoJsonBody: Action[JsValue] = Action(parse.json) { request =>
+      Ok(request.body)
+    }
+
+    def echoJsonInHeader: EssentialAction = Action(parse.json) { request =>
+      val name = (request.body \ "name").as[String]
+      val value = (request.body \ "value").as[String]
+      Ok.withHeaders(name -> value)
+    }
+
+    def echoJsonInCookie: EssentialAction = Action(parse.json) { request =>
+      val name = (request.body \ "name").as[String]
+      val value = (request.body \ "value").as[String]
+      Ok.withCookies(Cookie(name, value))
+    }
+
+    def echoJsonInSession: EssentialAction = Action(parse.json) { request =>
+      val sessionData = request.body.as[Map[String, String]]
+      Ok.withSession(sessionData.toSeq: _*)
+    }
+
+    def echoJsonInFlash: EssentialAction = Action(parse.json) { request =>
+      val flashData = request.body.as[Map[String, String]]
+      Ok.flashing(flashData.toSeq: _*)
+    }
+
+    def redirectToBody: EssentialAction = Action(parse.json) { request =>
+      val url = (request.body \ "url").as[String]
+      val status = (request.body \ "status").as[Int]
+      Redirect(url, status)
+    }
+  }
+
+  def method(name: String) = s"AsyncResultExtrators.$name"
+
+  s"${method("status")} should return the status code" in {
+    val ctrl = new TestEchoController
+    val request = FakeRequest("POST", "/test/status")
+    for {
+      result <- call(ctrl.echoTextBody, request)
+    } yield {
+      assertResult(Status.OK) {
+        status(result)
+      }
+    }
+  }
+
+  s"${method("contentType")} should extract the expected content type" in {
+    val ctrl = new TestEchoController
+    val testJson = Json.obj()
+    val request = FakeRequest("POST", "/test/contentType").withJsonBody(testJson)
+    for {
+      result <- call(ctrl.echoJsonBody, request)
+    } yield {
+      assertResult(Some(MimeTypes.JSON)) {
+        contentType(result)
+      }
+    }
+  }
+
+  s"${method("charset")} should extract the expected charset" in {
+    val ctrl = new TestEchoController
+    val testJson = Json.obj()
+    val request = FakeRequest("POST", "/test/charset").withJsonBody(testJson)
+    for {
+      result <- call(ctrl.echoJsonBody, request)
+    } yield {
+      assertResult(Some(Codec.utf_8.charset)) {
+        charset(result)
+      }
+    }
+  }
+
+  s"${method("contentAsString")} should extract the expected text" in {
+    val ctrl = new TestEchoController
+    val testString = "test"
+    val request = FakeRequest("POST", "/test/text").withTextBody(testString)
+    for {
+      result <- call(ctrl.echoTextBody, request)
+      resultBody <- contentAsString(result)
+    } yield {
+      assertResult(testString) {
+        resultBody
+      }
+    }
+  }
+
+  s"${method("contentAsJson")} should extract the expected json" in {
+    val ctrl = new TestEchoController
+    val testJson = Json.obj("expected" -> "json")
+    val request = FakeRequest("POST", "/test/json").withJsonBody(testJson)
+    for {
+      result <- call(ctrl.echoJsonBody, request)
+      resultBody <- contentAsJson(result)
+    } yield {
+      assertResult(testJson) {
+        resultBody
+      }
+    }
+  }
+
+  s"${method("header")} should extract the expected header" in {
+    val ctrl = new TestEchoController
+    val expectedHeaderName = "expected"
+    val expectedHeaderValue = "value"
+    val request = FakeRequest("POST", "/test/header").withJsonBody(Json.obj(
+      "name" ->  expectedHeaderName,
+      "value" -> expectedHeaderValue
+    ))
+    for {
+      result <- call(ctrl.echoJsonInHeader, request)
+    } yield {
+      assertResult(Some(expectedHeaderValue)) {
+        header(expectedHeaderName, result)
+      }
+    }
+  }
+
+  s"${method("cookies")} should extract the expected cookie" in {
+    val ctrl = new TestEchoController
+    val expectedCookie = Cookie("expected", "cookie")
+    val request = FakeRequest("POST", "/test/cookie").withJsonBody(Json.obj(
+      "name" -> expectedCookie.name,
+      "value" -> expectedCookie.value
+    ))
+    for {
+      result <- call(ctrl.echoJsonInCookie, request)
+    } yield {
+      assertResult(Some(expectedCookie)) {
+        cookies(result).get(expectedCookie.name)
+      }
+    }
+  }
+
+  s"${method("session")} should extract the expected session data" in {
+    val ctrl = new TestEchoController
+    val expectedSession = Session(Map("k1" -> "v1", "k2" -> "v2"))
+    val request = FakeRequest("POST", "/test/session").withJsonBody(Json.toJson(expectedSession.data))
+    for {
+      result <- call(ctrl.echoJsonInSession, request)
+    } yield {
+      assertResult(expectedSession) {
+        session(result)
+      }
+    }
+  }
+
+  s"${method("flash")} should extract the expected flash data" in {
+    val ctrl = new TestEchoController
+    val expectedFlash = Flash(Map("k1" -> "v1", "k2" -> "v2"))
+    val request = FakeRequest("POST", "/test/flash").withJsonBody(Json.toJson(expectedFlash.data))
+    for {
+      result <- call(ctrl.echoJsonInFlash, request)
+    } yield {
+      assertResult(expectedFlash) {
+        flash(result)
+      }
+    }
+  }
+
+  s"${method("redirectLocation")} should extract the expected redirect url from 301" in {
+    val ctrl = new TestEchoController
+    val redirectUrl = "test redirect"
+    val request = FakeRequest("POST", "/test/redirect").withJsonBody(Json.obj(
+      "url" -> redirectUrl,
+      "status" -> Status.MOVED_PERMANENTLY
+    ))
+    for {
+      result <- call(ctrl.redirectToBody, request)
+    } yield {
+      assertResult(Some(redirectUrl)) {
+        redirectLocation(result)
+      }
+    }
+  }
+
+  s"${method("redirectLocation")} should extract the expected redirect url from 302" in {
+    val ctrl = new TestEchoController
+    val redirectUrl = "test redirect"
+    val request = FakeRequest("POST", "/test/redirect").withJsonBody(Json.obj(
+      "url" -> redirectUrl,
+      "status" -> Status.FOUND
+    ))
+    for {
+      result <- call(ctrl.redirectToBody, request)
+    } yield {
+      assertResult(Some(redirectUrl)) {
+        redirectLocation(result)
+      }
+    }
+  }
+
+  s"${method("redirectLocation")} should extract the expected redirect url from 303" in {
+    val ctrl = new TestEchoController
+    val redirectUrl = "test redirect"
+    val request = FakeRequest("POST", "/test/redirect").withJsonBody(Json.obj(
+      "url" -> redirectUrl,
+      "status" -> Status.SEE_OTHER
+    ))
+    for {
+      result <- call(ctrl.redirectToBody, request)
+    } yield {
+      assertResult(Some(redirectUrl)) {
+        redirectLocation(result)
+      }
+    }
+  }
+
+  s"${method("redirectLocation")} should extract the expected redirect url from 307" in {
+    val ctrl = new TestEchoController
+    val redirectUrl = "test redirect"
+    val request = FakeRequest("POST", "/test/redirect").withJsonBody(Json.obj(
+      "url" -> redirectUrl,
+      "status" -> Status.TEMPORARY_REDIRECT
+    ))
+    for {
+      result <- call(ctrl.redirectToBody, request)
+    } yield {
+      assertResult(Some(redirectUrl)) {
+        redirectLocation(result)
+      }
+    }
+  }
+
+  s"${method("redirectLocation")} should NOT extract a redirect url from a 400" in {
+    val ctrl = new TestEchoController
+    val redirectUrl = "test redirect"
+    val request = FakeRequest("POST", "/test/redirect").withJsonBody(Json.obj(
+      "url" -> redirectUrl,
+      "status" -> Status.BAD_REQUEST
+    ))
+    for {
+      result <- call(ctrl.redirectToBody, request)
+    } yield {
+      assertResult(None) {
+        redirectLocation(result)
+      }
+    }
+  }
+}
+
+

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,10 @@
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M12")
+resolvers += Classpaths.sbtPluginReleases
+resolvers += Resolver.url(
+  "bintray-sbt-plugin-releases",
+  url("http://dl.bintray.com/content/sbt/sbt-plugin-releases"))(
+    Resolver.ivyStylePatterns)
+
+addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
 


### PR DESCRIPTION
@PainterAndHacker @egprentice @patrick-bohan @htmldoug @rcmurphy (and anyone interested in Play + ScalaTest > 3.0)

I created this open-source library as a means to make testing Play code easier with ScalaTest 3.0 async style tests.

In `AsyncTestSuite`s, you return a `Future[Assertion]` instead of `Any`. The standard Play test code takes things like:

``` scala
def contentAsJson(of: Future[Result])(implicit timeout: Timeout): JsValue
```

And awaits on the result of the controller before returning the resulting json body. This doesn't work with Async suites and is blocking.

This basically mimics all of the functionality but does not operate on `Future` but rather just plain `Result`. In some cases, such as `contentAsJson` the result must also be a `Future` because it is consuming an Iteratee. For example:

``` scala
def contentAsJson(result: Result)(implicit ec: ExecutionContext): Future[JsValue]
```

In these cases, I also allow providing a custom execution context. It is easy to just `flatMap` over these things in order to put all your assertions in the `for / yield`. This `Future[Assertion]` is then yielded to scalatest to complete the assertions asynchronously at some later time.

All this stuff is pretty much copped from https://github.com/playframework/playframework/blob/b692d1714b74864d9c86ab0708f3d349a5759072/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala#L276-L445
