### PR TITLE
Support Play 2.5.12 and create 1.0.0-RC1 release candidate

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2016 Jeff May
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,7 @@ val coreCommonSettings = commonSettings ++ Seq(
   libraryDependencies ++= Seq(
     "com.typesafe.play" %% "play" % playVersion.value,
     "com.typesafe.play" %% "play-test" % playVersion.value % "test",
-    "org.scalatest" %% "scalatest" % "3.0.0" % "test"
+    "org.scalatest" %% "scalatest" % "3.0.0" % Test
   )
 )
 
@@ -70,5 +70,5 @@ lazy val `play25-core` = (project in file("play25-core"))
   .settings(coreCommonSettings)
   .settings(
     name := "play25-test-ops-core",
-    playVersion := "2.5.3"
+    playVersion := "2.5.12"
   )

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ lazy val root = (project in file("."))
 
 val commonSettings = commonRootSettings ++ Seq(
 
-  version := "0.2.2",
+  version := "1.0.0-RC1",
 
   scalacOptions ++= Seq(
     "-encoding", "UTF-8",

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,11 @@ val commonRootSettings = Seq(
   organizationName := "Jeff May",
   
   // set the scala version on the root project
-  scalaVersion := "2.11.8"
+  scalaVersion := "2.11.8",
+
+  // fail the build if the coverage drops below the minimum
+  coverageFailOnMinimum := true,
+  coverageMinimum := 80
 )
 
 lazy val root = (project in file("."))
@@ -52,6 +56,7 @@ val commonSettings = commonRootSettings ++ Seq(
 lazy val playVersion = settingKey[String]("The version of Play Framework")
 
 val coreCommonSettings = commonSettings ++ Seq(
+  coverageMinimum := 80,
   libraryDependencies ++= Seq(
     "com.typesafe.play" %% "play" % playVersion.value,
     "com.typesafe.play" %% "play-test" % playVersion.value % "test",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.13


### PR DESCRIPTION
@usufruct @htmldoug just giving this repo some love.

I didn't like the way play structured tests using awaits and preferred a consistent `for / yield` syntax. Now that ScalaTest 3.x accepts a `Future[Assertion]` for a test specification, this allows you to do:

```scala
for {
  rsp <- call(ctrl.method, FakeRequest())
  _ = assertResult(OK)(rsp.header.status)
  body <- contentAsJson(rsp)
  res <- service.method(body.as[Thing])
} yield {
  assertResult(res)(expectedThing)
}
```

Instead of:

```scala
val rsp = call(ctrl.method, FakeRequest())
assertResult(OK)(rsp.header.status)
val body = contentAsJson(rsp)
val futureRes = service.method(body.as[Thing])
for {
  res <- futureRes
} yield {
  assertResult(Json.obj())(body)
}
```