### PR TITLE
Update build to publish to rallyhealth bintray repo / codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
 language: scala
 scala:
   - 2.11.12
-  - 2.12.6
 jdk:
   - openjdk8
 
 script:
-  - sbt clean coverage +test coverageReport && sbt coverageAggregate
+  - sbt clean +coverage +test +coverageReport && sbt coverageAggregate
+
 after_success:
-  - sbt coveralls
+  # Upload coverage reports to codecov.io
+  - bash <(curl -s https://codecov.io/bash) -t 60a8d8f2-fa0c-4bd5-8631-539c4e6bcf37
 
   # Tricks to avoid unnecessary cache updates
   - find $HOME/.sbt -name "*.lock" | xargs rm

--- a/build.sbt
+++ b/build.sbt
@@ -2,13 +2,16 @@ import Dependencies._
 
 name := "play-test-ops-root"
 
-ThisBuild / organization := "me.jeffmay"
-ThisBuild / organizationName := "Jeff May"
+ThisBuild / organization := "com.rallyhealth"
+ThisBuild / organizationName := "Rally Health"
 
 // set the scala version on the root project
 ThisBuild / scalaVersion := Scala_2_11
 
-ThisBuild / licenses += ("Apache-2.0", url("http://opensource.org/licenses/apache-2.0"))
+ThisBuild / bintrayOrganization := Some("rallyhealth")
+ThisBuild / bintrayRepository := "maven"
+
+ThisBuild / licenses += ("MIT", url("https://opensource.org/licenses/MIT"))
 
 def commonProject(id: String, path: String): Project = {
   Project(id, file(path)).settings(
@@ -48,13 +51,14 @@ def coreProject(includePlayVersion: String): Project = {
     name := s"play$playSuffix-test-ops-core",
     scalaVersion := scalaVersions.head,
     crossScalaVersions := scalaVersions,
-    semVerEnforceAfterVersion := Some("1.1.0"),
+    semVerEnforceAfterVersion := Some("1.2.0"),
     // fail the build if the coverage drops below the minimum
     coverageMinimum := 80,
     coverageFailOnMinimum := true,
     // add library dependencies
     resolvers ++= Seq(
-      "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
+      "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/",
+      Resolver.bintrayRepo("rallyhealth", "maven")
     ),
     libraryDependencies ++= Seq(
       playServer(includePlayVersion)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,5 +2,4 @@ resolvers += Resolver.bintrayIvyRepo("rallyhealth", "sbt-plugins")
 
 addSbtPlugin("com.rallyhealth.sbt" %% "sbt-git-versioning" % "1.2.0")
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.5")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0-M4")


### PR DESCRIPTION
@rallyhealth/engineers @sklei2 @usufruct99 @mingy711

This converts the repo to publish to our Rally open-source bintray: https://bintray.com/rallyhealth/maven

It also converts over to codecov.io: https://codecov.io/gh/rallyhealth/play-test-ops

And changes the license to our standard MIT license.