### PR TITLE
Add support for Scala 2.11 for Play 2.7 to help upgrade path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jdk:
   - openjdk11
 
 script:
-  - sbt clean +coverage +test +coverageReport && sbt coverageAggregate
+  - sbt clean +coverage +test coverageAggregate
 
 after_success:
   # Upload coverage reports to codecov.io

--- a/build.sbt
+++ b/build.sbt
@@ -5,9 +5,6 @@ name := "play-test-ops-root"
 ThisBuild / organization := "com.rallyhealth"
 ThisBuild / organizationName := "Rally Health"
 
-// set the scala version on the root project
-ThisBuild / scalaVersion := Scala_2_11
-
 ThisBuild / bintrayOrganization := Some("rallyhealth")
 ThisBuild / bintrayRepository := "maven"
 
@@ -24,8 +21,8 @@ publishLocal / skip := true
   */
 val suppressSemVerCheckOfNewScalaVersionsUntilNextVersion = semVerCheck := {
   version.value match {
-    case VersionNumber(Seq(1, 1, 3 | 4, _*), _, _) => Def.task {}
-    case VersionNumber(Seq(1, 2, 0, _*), _, _) => Def.task {}
+    case VersionNumber(Seq(1, 2, 0 | 1, _*), _, _) => Def.task {}
+    case VersionNumber(Seq(1, 3, 0, _*), _, _) => Def.task {}
     case _ =>
       throw new RuntimeException(s"Version bump! Time to remove the suppression of semver checking.")
   }
@@ -69,18 +66,19 @@ def coreProject(includePlayVersion: String): Project = {
   val scalaVersions = includePlayVersion match {
     case Play_2_5 => Seq(Scala_2_11)
     case Play_2_6 => Seq(Scala_2_11, Scala_2_12)
-    case Play_2_7 => Seq(Scala_2_12, Scala_2_13)
+    case Play_2_7 => Seq(Scala_2_11, Scala_2_12, Scala_2_13)
   }
   val path = s"play$playSuffix-core"
   commonProject(path, path).settings(
     name := s"play$playSuffix-test-ops-core",
+    scalaVersion := scalaVersions.head,
     crossScalaVersions := scalaVersions,
     // fail the build if the coverage drops below the minimum
     coverageMinimum := 80,
     coverageFailOnMinimum := true,
     // add library dependencies
     resolvers ++= Seq(
-      "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/",
+      "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/",
       Resolver.bintrayRepo("rallyhealth", "maven")
     ),
     libraryDependencies ++= Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,11 +4,11 @@ object Dependencies {
 
   final val Scala_2_11 = "2.11.12"
   final val Scala_2_12 = "2.12.6"
-  final val Scala_2_13 = "2.13.0"
+  final val Scala_2_13 = "2.13.1"
 
   final val Play_2_5 = "2.5.19"
   final val Play_2_6 = "2.6.19"
-  final val Play_2_7 = "2.7.3"
+  final val Play_2_7 = "2.7.4"
 
   def playServer(includePlayVersion: String): ModuleID = {
     "com.typesafe.play" %% "play" % includePlayVersion
@@ -19,6 +19,6 @@ object Dependencies {
   }
 
   val scalaTest: ModuleID = {
-    "org.scalatest" %% "scalatest" % "3.0.8"
+    "org.scalatest" %% "scalatest" % "3.1.1"
   }
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 resolvers += Resolver.bintrayIvyRepo("rallyhealth", "sbt-plugins")
 
-addSbtPlugin("com.rallyhealth.sbt" %% "sbt-git-versioning" % "1.2.0")
+addSbtPlugin("com.rallyhealth.sbt" %% "sbt-git-versioning" % "1.4.0")
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")


### PR DESCRIPTION
In order to ease the transition from Play 2.5 / Scala 2.11 to Play 2.7 / Scala 2.13, we should allow pulling in the latest version for Scala 2.11 in Play 2.7.