### PR TITLE
Fix 1.4.0 upgrade by change the semver check to handle 1.4.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,8 @@ publishLocal / skip := true
   */
 val suppressSemVerCheckOfNewModuleUntilNextVersion = semVerCheck := {
   version.value match {
-    case VersionNumber(Seq(1, 3, 0 | 1, _*), _, _) => Def.task {}
+    case VersionNumber(Seq(1, x, _*), _, _) if x <= 3 => Def.task {}
+    case VersionNumber(Seq(1, 4, 0, _*), _, _) => Def.task {}
     case _ =>
       throw new RuntimeException(s"Version bump! Time to remove the suppression of semver checking.")
   }


### PR DESCRIPTION
There was an issue publishing the release because tagging the release with 1.4.0 would cause the publish job to fail