### PR TITLE
Upgrade library and plugin versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.log
 
 # sbt specific
+.bsp
 .cache
 .history
 .lib/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,31 @@
 language: scala
 scala:
-  - 2.11.12
+  - 2.13.5
 jdk:
   - openjdk8
   - openjdk11
 
+before_script:
+  # Download sbt because Travis can't find it automatically :(
+  - mkdir -p $HOME/.sbt/launchers/1.5.0/
+  - curl -L -o $HOME/.sbt/launchers/1.5.0/sbt-launch.jar https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.5.0/sbt-launch-1.5.0.jar
+
 script:
-  - sbt clean +coverage +test coverageAggregate
+  - sbt clean +coverage +test coverageAggregate +mimaReportBinaryIssues
 
 after_success:
   # Upload coverage reports to codecov.io
   - bash <(curl -s https://codecov.io/bash)
 
-  # Tricks to avoid unnecessary cache updates
-  - find $HOME/.sbt -name "*.lock" | xargs rm
-  - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
+# Avoid unnecessary cache updates
+before_cache:
+  - rm -fv $HOME/.ivy2/.sbt.ivy.lock
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
+  - find $HOME/.sbt        -name "*.lock"               -print -delete
 
 # These directories are cached to S3 at the end of the build
 cache:
   directories:
+    - $HOME/.cache/coursier
     - $HOME/.ivy2/cache
-    - $HOME/.sbt/boot/
+    - $HOME/.sbt

--- a/play25-core/src/test/scala/play/api/test/ops/AsyncResultExtractorsSpec.scala
+++ b/play25-core/src/test/scala/play/api/test/ops/AsyncResultExtractorsSpec.scala
@@ -4,6 +4,7 @@ import akka.stream.Materializer
 import org.scalatest.freespec.AsyncFreeSpec
 import org.scalatest.{Args, Status => TestStatus}
 import play.api.http.{MimeTypes, Status}
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc._
 import play.api.test._
@@ -16,7 +17,7 @@ class AsyncResultExtractorsSpec extends AsyncFreeSpec
   with EssentialActionCaller
   with Writeables {
 
-  implicit private lazy val app: Application = FakeApplication()
+  private lazy val app: Application = GuiceApplicationBuilder().build()
   implicit private lazy val mat: Materializer = app.materializer
   implicit private lazy val ec: ExecutionContext = mat.executionContext
 

--- a/play25-core/src/test/scala/play/api/test/ops/AsyncResultExtractorsSpec.scala
+++ b/play25-core/src/test/scala/play/api/test/ops/AsyncResultExtractorsSpec.scala
@@ -1,7 +1,8 @@
 package play.api.test.ops
 
 import akka.stream.Materializer
-import org.scalatest.{Args, AsyncFreeSpec, Status => TestStatus}
+import org.scalatest.freespec.AsyncFreeSpec
+import org.scalatest.{Args, Status => TestStatus}
 import play.api.http.{MimeTypes, Status}
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc._

--- a/play26-core/src/test/scala/play/api/test/ops/AsyncResultExtractorsSpec.scala
+++ b/play26-core/src/test/scala/play/api/test/ops/AsyncResultExtractorsSpec.scala
@@ -2,7 +2,8 @@ package play.api.test.ops
 
 import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, Materializer}
-import org.scalatest.{AsyncFreeSpec, BeforeAndAfterAll}
+import org.scalatest.freespec.AsyncFreeSpec
+import org.scalatest.BeforeAndAfterAll
 import play.api.http.{MimeTypes, Status}
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc._

--- a/play26-core/src/test/scala/play/api/test/ops/AsyncResultExtractorsSpec.scala
+++ b/play26-core/src/test/scala/play/api/test/ops/AsyncResultExtractorsSpec.scala
@@ -9,7 +9,7 @@ import play.api.libs.json.{JsValue, Json}
 import play.api.mvc._
 import play.api.test._
 
-import scala.concurrent.Await
+import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration._
 
 class AsyncResultExtractorsSpec extends AsyncFreeSpec
@@ -18,6 +18,7 @@ class AsyncResultExtractorsSpec extends AsyncFreeSpec
   with EssentialActionCaller
   with Writeables {
 
+  override implicit val executionContext: ExecutionContext = ExecutionContext.global
   implicit private lazy val sys: ActorSystem = ActorSystem(getClass.getSimpleName)
   implicit private lazy val mat: Materializer = ActorMaterializer()
 

--- a/play27-core/src/test/scala/play/api/test/ops/AsyncResultExtractorsSpec.scala
+++ b/play27-core/src/test/scala/play/api/test/ops/AsyncResultExtractorsSpec.scala
@@ -2,7 +2,8 @@ package play.api.test.ops
 
 import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, Materializer}
-import org.scalatest.{AsyncFreeSpec, BeforeAndAfterAll}
+import org.scalatest.freespec.AsyncFreeSpec
+import org.scalatest.BeforeAndAfterAll
 import play.api.http.{MimeTypes, Status}
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc._

--- a/play28-core/src/test/scala/play/api/test/ops/AsyncResultExtractorsSpec.scala
+++ b/play28-core/src/test/scala/play/api/test/ops/AsyncResultExtractorsSpec.scala
@@ -2,9 +2,10 @@ package play.api.test.ops
 
 import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, Materializer}
+import org.scalatest.freespec.AsyncFreeSpec
 // Despite the package name this is from play-test
 import akka.stream.testkit.NoMaterializer
-import org.scalatest.{AsyncFreeSpec, BeforeAndAfterAll}
+import org.scalatest.BeforeAndAfterAll
 import play.api.http.{MimeTypes, Status}
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc._

--- a/play28-core/src/test/scala/play/api/test/ops/AsyncResultExtractorsSpec.scala
+++ b/play28-core/src/test/scala/play/api/test/ops/AsyncResultExtractorsSpec.scala
@@ -1,7 +1,7 @@
 package play.api.test.ops
 
 import akka.actor.ActorSystem
-import akka.stream.{ActorMaterializer, Materializer}
+import akka.stream.Materializer
 import org.scalatest.freespec.AsyncFreeSpec
 // Despite the package name this is from play-test
 import akka.stream.testkit.NoMaterializer
@@ -20,8 +20,8 @@ class AsyncResultExtractorsSpec extends AsyncFreeSpec
   with EssentialActionCaller
   with Writeables {
 
-  implicit private lazy val sys: ActorSystem = ActorSystem(getClass.getSimpleName)
-  implicit private lazy val mat: Materializer = ActorMaterializer()
+  private lazy val sys: ActorSystem = ActorSystem(getClass.getSimpleName)
+  implicit private lazy val mat: Materializer = Materializer(sys)
 
   override protected def afterAll(): Unit = {
     Await.ready(sys.terminate(), 1.second)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,13 +3,14 @@ import sbt._
 object Dependencies {
 
   final val Scala_2_11 = "2.11.12"
-  final val Scala_2_12 = "2.12.6"
-  final val Scala_2_13 = "2.13.1"
+  // Can't upgrade to Scala 2.12.13 because of https://github.com/scoverage/sbt-scoverage/issues/321
+  final val Scala_2_12 = "2.12.12"
+  final val Scala_2_13 = "2.13.5"
 
   final val Play_2_5 = "2.5.19"
-  final val Play_2_6 = "2.6.19"
-  final val Play_2_7 = "2.7.4"
-  final val Play_2_8 = "2.8.3"
+  final val Play_2_6 = "2.6.25"
+  final val Play_2_7 = "2.7.9"
+  final val Play_2_8 = "2.8.7"
 
   def playServer(includePlayVersion: String): ModuleID = {
     "com.typesafe.play" %% "play" % includePlayVersion
@@ -20,6 +21,6 @@ object Dependencies {
   }
 
   val scalaTest: ModuleID = {
-    "org.scalatest" %% "scalatest" % "3.1.1"
+    "org.scalatest" %% "scalatest" % "3.2.7"
   }
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.0
+sbt.version=1.5.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,4 @@
-resolvers += Resolver.bintrayIvyRepo("rallyhealth", "sbt-plugins")
-
-addSbtPlugin("com.rallyhealth.sbt" %% "sbt-git-versioning" % "1.4.0")
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.8.1")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.6.1")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")


### PR DESCRIPTION
- Upgrade build configs to use latest versions and new sbt plugins
  - Set root scalaVersion to 2.13.5
  - Use sbt-dynver and sbt-mima plugins
  - Remove sbt-git-versioning
  - Remove unused resolvers
  - Upgrade to sbt 1.5.0
  - Upgrade Scala versions
  - Add documentation about why use Scala 2.12.12 instead of 2.12.13
  - Upgrade ScalaTest to 3.2.7
  - Upgrade to latest Play versions
  - Update .travis.yml build configs to test for binary compatibility with sbt-mima plugin
- Fix deprecation warnings, remove unnecessary implicits, and fix tests
  - Use GuiceApplicationBuilder instead of default ApplicationBuilder
  - Avoid use of deprecated Play methods
  - Use global execution context to avoid deadlock in scalatest