### PR TITLE
Update build configs to publish to Sonatype

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,15 +5,17 @@ name := "play-test-ops-root"
 ThisBuild / organization := "com.rallyhealth"
 ThisBuild / organizationName := "Rally Health"
 
+ThisBuild / versionScheme := Some("early-semver")
 ThisBuild / scalaVersion := "2.13.5"
-
-ThisBuild / bintrayOrganization := Some("rallyhealth")
-ThisBuild / bintrayRepository := "maven"
-
 ThisBuild / licenses += ("MIT", url("https://opensource.org/licenses/MIT"))
 
 // reload sbt when the build files change
 Global / onChangedBuildSource := ReloadOnSourceChanges
+
+// if you contribute to this library, please add yourself to this list!
+developers := List(
+  Developer(id = "jeffmay", name = "Jeff May", email = "jeff.n.may@gmail.com", url = url("https://github.com/jeffmay")),
+)
 
 // don't publish the jars for the root project (http://stackoverflow.com/a/8789341)
 publish / skip := true

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.8.1")
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.6.1")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.7")

--- a/sonatype.sbt
+++ b/sonatype.sbt
@@ -1,0 +1,22 @@
+// Your profile name of the sonatype account. The default is the same with the organization value
+sonatypeProfileName := "com.rallyhealth"
+
+// To sync with Maven central, you need to supply the following information:
+publishMavenStyle := true
+
+// publish to Maven Central
+ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org"
+ThisBuild / publishTo := Some {
+  if (isSnapshot.value)
+    Resolver.url("Sonatype", url("https://s01.oss.sonatype.org/content/repositories/snapshots"))
+  else
+    Resolver.url("Sonatype", url("https://s01.oss.sonatype.org/content/repositories/releases"))
+}
+
+// add SNAPSHOT to non-release versions so they are not published to the main repo
+ThisBuild / dynverSonatypeSnapshots := true
+// Use '-' instead of '+' for simpler snapshot URLs
+ThisBuild / dynverSeparator := "-"
+
+import xerial.sbt.Sonatype.GitHubHosting
+sonatypeProjectHosting := Some(GitHubHosting("rallyhealth", "play-test-ops", "jeff.n.may@gmail.com"))


### PR DESCRIPTION
I was able to successfully publish snapshots to https://s01.oss.sonatype.org/content/repositories/snapshots/com/rallyhealth/ with these changes.