### PR TITLE
Play 2.9 and 3.0 on Scala 2.13 and 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,4 @@
 [![Build Status](https://travis-ci.org/rallyhealth/play-test-ops.svg?branch=master)](https://travis-ci.org/rallyhealth/play-test-ops)
-[![codecov](https://codecov.io/gh/rallyhealth/play-test-ops/branch/master/graph/badge.svg)](https://codecov.io/gh/rallyhealth/play-test-ops)
-
-| play25-test-ops-core | play26-test-ops-core | play27-test-ops-core | play28-test-ops-core |
-| :------------------: | :------------------: | :------------------: | :------------------: |
-| [ ![Download](https://api.bintray.com/packages/rallyhealth/maven/play25-test-ops-core/images/download.svg) ](https://bintray.com/rallyhealth/maven/play25-test-ops-core/_latestVersion) | [ ![Download](https://api.bintray.com/packages/rallyhealth/maven/play26-test-ops-core/images/download.svg) ](https://bintray.com/rallyhealth/maven/play26-test-ops-core/_latestVersion) | [ ![Download](https://api.bintray.com/packages/rallyhealth/maven/play27-test-ops-core/images/download.svg) ](https://bintray.com/rallyhealth/maven/play27-test-ops-core/_latestVersion) | [ ![Download](https://api.bintray.com/packages/rallyhealth/maven/play28-test-ops-core/images/download.svg) ](https://bintray.com/rallyhealth/maven/play28-test-ops-core/_latestVersion) |
 
 # Introduction
 
@@ -12,6 +7,23 @@ with the following features:
 
 - AsyncResultExtractors: Instead of blocking for a result, extract the content into Futures
   and let the testing framework handle it for you.
+
+Published to [Maven Central](https://search.maven.org/artifact/com.rallyhealth/play28-test-ops-core_2.13). 
+Example dependency in sbt on the play28-specific artifact:
+```scala
+libraryDependencies += "com.rallyhealth" %% "play28-test-ops-core" % "version"
+```
+
+Scala Versions supported:
+
+| Artifact             |      Scala 2.11       |      Scala 2.12      |      Scala 2.13      |       Scala 3        |
+|----------------------|:---------------------:|:--------------------:|:--------------------:|:--------------------:|
+| play25-test-ops-core |  :white_check_mark:   |                      |                      |                      |
+| play26-test-ops-core |  :white_check_mark:   |  :white_check_mark:  |                      |                      |
+| play27-test-ops-core |  :white_check_mark:   |  :white_check_mark:  |  :white_check_mark:  |                      |
+| play28-test-ops-core |                       |  :white_check_mark:  |  :white_check_mark:  |                      |
+| play29-test-ops-core |                       |                      |  :white_check_mark:  |  :white_check_mark:  |
+| play30-test-ops-core |                       |                      |  :white_check_mark:  |  :white_check_mark:  |
 
 # Usage
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,13 +1,13 @@
 import Dependencies._
 
 name := "play-test-ops-root"
-scalaVersion := "2.13.5"
+scalaVersion := Scala_2_13
 
 ThisBuild / organization := "com.rallyhealth"
 ThisBuild / organizationName := "Rally Health"
 
 ThisBuild / versionScheme := Some("early-semver")
-ThisBuild / scalaVersion := "2.13.5"
+ThisBuild / scalaVersion := Scala_2_13
 ThisBuild / licenses += ("MIT", url("https://opensource.org/licenses/MIT"))
 
 // reload sbt when the build files change
@@ -17,7 +17,11 @@ ThisBuild / homepage := Some(url("https://github.com/play-test-ops"))
 // if you contribute to this library, please add yourself to this list!
 ThisBuild / developers := List(
   Developer(id = "jeffmay", name = "Jeff May", email = "jeff.n.may@gmail.com", url = url("https://github.com/jeffmay")),
+  Developer(id = "russellremple", name = "Russ Remple", email = "russell.remple@optum.com", url = url("https://github.com/russellremple")),
 )
+
+// scoverage and twirl depend different versions
+ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % "always"
 
 // don't publish the jars for the root project (http://stackoverflow.com/a/8789341)
 publish / skip := true
@@ -25,16 +29,17 @@ publish / skip := true
 // don't search for previous artifact of the root project
 mimaFailOnNoPrevious := false
 
-def commonProject(id: String, path: String): Project = {
-  Project(id, file(path)).settings(
+def commonProject: Seq[Def.Setting[_]] =
+  Seq(
     scalacOptions ++= Seq(
       "-encoding",
       "UTF-8",
       "-deprecation:false",
       "-feature",
       "-Xfatal-warnings",
-      "-Ywarn-dead-code"
-    ),
+    ) ++ (if (scalaBinaryVersion.value == "3") Seq() else Seq("-Ywarn-dead-code")),
+    // Disable coverage for Scala 2.11 -- sbt-scoverage no longer supports it
+    coverageEnabled := (if (scalaBinaryVersion.value == "2.11") false else coverageEnabled.value),
     // don't publish the test code
     Test / publishArtifact := false,
     // disable compilation of ScalaDocs, since this always breaks on links
@@ -42,23 +47,24 @@ def commonProject(id: String, path: String): Project = {
     // disable publishing empty ScalaDocs
     Compile / packageDoc / publishArtifact := false
   )
-}
 
-def coreProject(includePlayVersion: String): Project = {
+def coreProject(includePlayVersion: String): Seq[Def.Setting[_]] = {
   val playSuffix = includePlayVersion match {
     case Play_2_5 => "25"
     case Play_2_6 => "26"
     case Play_2_7 => "27"
     case Play_2_8 => "28"
+    case Play_2_9 => "29"
+    case Play_3_0 => "30"
   }
   val scalaVersions = includePlayVersion match {
     case Play_2_5 => Seq(Scala_2_11)
     case Play_2_6 => Seq(Scala_2_11, Scala_2_12)
     case Play_2_7 => Seq(Scala_2_11, Scala_2_12, Scala_2_13)
     case Play_2_8 => Seq(Scala_2_12, Scala_2_13)
+    case Play_2_9 | Play_3_0 => Seq(Scala_2_13, Scala_3)
   }
-  val path = s"play$playSuffix-core"
-  commonProject(path, path).settings(
+  commonProject ++ Seq(
     name := s"play$playSuffix-test-ops-core",
     scalaVersion := scalaVersions.head,
     crossScalaVersions := scalaVersions,
@@ -66,20 +72,40 @@ def coreProject(includePlayVersion: String): Project = {
       organization.value %% name.value % "1.5.0"
     ),
     // fail the build if the coverage drops below the minimum
-    coverageMinimum := 80,
+    coverageMinimumStmtTotal := (
+      // Right now Scala3 does not support a way to exclude packages or files from being instrumented.
+      // https://github.com/scoverage/scalac-scoverage-plugin/blob/main/README.md
+      if (scalaBinaryVersion.value == "3") 79
+      else 90
+      ),
     coverageFailOnMinimum := true,
     // add library dependencies
-    libraryDependencies ++= Seq(playServer(includePlayVersion)) ++ Seq(
-      // Test-only dependencies
+    libraryDependencies ++= Seq(
+      playServer(includePlayVersion),
       playTest(includePlayVersion),
-      scalaTest
-    ).map(_ % Test)
+      scalaTest(includePlayVersion)
+    )
   )
 }
 
-lazy val `play25-core` = coreProject(Play_2_5)
-lazy val `play26-core` = coreProject(Play_2_6)
-lazy val `play27-core` = coreProject(Play_2_7)
-lazy val `play28-core` = coreProject(Play_2_8).settings(
-  libraryDependencies ++= Seq(playTest(Play_2_8))
+lazy val `play25-core` = project.settings(coreProject(Play_2_5))
+lazy val `play26-core` = project.settings(coreProject(Play_2_6))
+lazy val `play27-core` = project.settings(coreProject(Play_2_7))
+
+lazy val `play28-core` = project.settings(coreProject(Play_2_8)).settings(
+  // Akka references are in a separate source root to facilitate sharing other sources with the Play 3.0 project
+  Compile / unmanagedSourceDirectories += (Compile / sourceDirectory).value / "scala-akka"
+)
+
+lazy val `play29-core` = project.settings(coreProject(Play_2_9)).settings(
+  Compile / sourceDirectory := (`play28-core` / Compile / sourceDirectory).value,
+  Test / sourceDirectory := (`play28-core` / Test / sourceDirectory).value,
+  // Uses the same Akka type/object references as the Play 2.8 project
+  Compile / unmanagedSourceDirectories += (Compile / sourceDirectory).value / "scala-akka"
+)
+
+lazy val `play30-core` = project.settings(coreProject(Play_3_0)).settings(
+  // Uses locally-defined Pekko type/object references, so only reference non-Akka sources in the Play 2.8 project
+  Compile / unmanagedSourceDirectories += (`play28-core` / Compile / sourceDirectory).value / "scala",
+  Test / unmanagedSourceDirectories += (`play28-core` / Test / sourceDirectory).value / "scala"
 )

--- a/play28-core/src/main/scala-akka/play/api/test/ops/ActorTypes.scala
+++ b/play28-core/src/main/scala-akka/play/api/test/ops/ActorTypes.scala
@@ -1,0 +1,14 @@
+package play.api.test.ops
+
+trait ActorTypes {
+  type ActorSystem = akka.actor.ActorSystem
+  type ByteString = akka.util.ByteString
+  type Materializer = akka.stream.Materializer
+
+  val ActorSystem = akka.actor.ActorSystem
+  val Materializer = akka.stream.Materializer
+  // Despite the package name this is from play-test
+  val NoMaterializer = akka.stream.testkit.NoMaterializer
+}
+
+object ActorTypes extends ActorTypes

--- a/play28-core/src/main/scala/play/api/test/ops/AsyncResultExtractors.scala
+++ b/play28-core/src/main/scala/play/api/test/ops/AsyncResultExtractors.scala
@@ -1,9 +1,6 @@
 package play.api.test.ops
 
-import akka.stream.Materializer
-// Despite the package name this is from play-test
-import akka.stream.testkit.NoMaterializer
-import akka.util.ByteString
+import play.api.test.ops.ActorTypes._
 import play.api.http.HeaderNames._
 import play.api.http.Status._
 import play.api.libs.json.{JsValue, Json}

--- a/play28-core/src/test/scala/play/api/test/ops/AsyncResultExtractorsSpec.scala
+++ b/play28-core/src/test/scala/play/api/test/ops/AsyncResultExtractorsSpec.scala
@@ -1,10 +1,7 @@
 package play.api.test.ops
 
-import akka.actor.ActorSystem
-import akka.stream.Materializer
+import play.api.test.ops.ActorTypes._
 import org.scalatest.freespec.AsyncFreeSpec
-// Despite the package name this is from play-test
-import akka.stream.testkit.NoMaterializer
 import org.scalatest.BeforeAndAfterAll
 import play.api.http.{MimeTypes, Status}
 import play.api.libs.json.{JsValue, Json}
@@ -70,7 +67,7 @@ class AsyncResultExtractorsSpec extends AsyncFreeSpec
     }
   }
 
-  protected def method(name: String) = s"play27.AsyncResultExtractors.$name"
+  protected def method(name: String) = s"play28+.AsyncResultExtractors.$name"
 
   behave like parsesContentUsing("ActorMaterializer", mat)
   behave like parsesContentUsing("NoMaterializer", NoMaterializer)

--- a/play30-core/src/main/scala/play/api/test/ops/ActorTypes.scala
+++ b/play30-core/src/main/scala/play/api/test/ops/ActorTypes.scala
@@ -1,0 +1,14 @@
+package play.api.test.ops
+
+trait ActorTypes {
+  type ActorSystem = org.apache.pekko.actor.ActorSystem
+  type ByteString = org.apache.pekko.util.ByteString
+  type Materializer = org.apache.pekko.stream.Materializer
+
+  val ActorSystem = org.apache.pekko.actor.ActorSystem
+  val Materializer = org.apache.pekko.stream.Materializer
+  // Despite the package name this is from play-test
+  val NoMaterializer = org.apache.pekko.stream.testkit.NoMaterializer
+}
+
+object ActorTypes extends ActorTypes

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,22 +5,40 @@ object Dependencies {
   final val Scala_2_11 = "2.11.12"
   // Can't upgrade to Scala 2.12.13 because of https://github.com/scoverage/sbt-scoverage/issues/321
   final val Scala_2_12 = "2.12.12"
-  final val Scala_2_13 = "2.13.5"
+  final val Scala_2_13 = "2.13.12"
+  final val Scala_3 = "3.3.1"
 
   final val Play_2_5 = "2.5.19"
   final val Play_2_6 = "2.6.25"
   final val Play_2_7 = "2.7.9"
-  final val Play_2_8 = "2.8.7"
+  final val Play_2_8 = "2.8.21"
+  final val Play_2_9 = "2.9.0"
+  final val Play_3_0 = "3.0.0"
+
+  def playOrg(includePlayVersion: String): String = includePlayVersion match {
+    case Play_3_0 => "org.playframework"
+    case _ => "com.typesafe.play"
+  }
 
   def playServer(includePlayVersion: String): ModuleID = {
-    "com.typesafe.play" %% "play" % includePlayVersion
+    playOrg(includePlayVersion) %% "play" % includePlayVersion
   }
 
+  // Test config only through Play 2.7
   def playTest(includePlayVersion: String): ModuleID = {
-    "com.typesafe.play" %% "play-test" % includePlayVersion
+    val module = playOrg(includePlayVersion) %% "play-test" % includePlayVersion
+    includePlayVersion match {
+      case Play_2_8 | Play_2_9 | Play_3_0 => module
+      case _ => module % Test
+    }
   }
 
-  val scalaTest: ModuleID = {
-    "org.scalatest" %% "scalatest" % "3.2.7"
+  // Test-only dependency
+  def scalaTest(includePlayVersion: String): ModuleID = {
+    val scalatestVersion = includePlayVersion match {
+      case Play_2_9 | Play_3_0 => "3.2.15"
+      case _ => "3.2.7"
+    }
+    "org.scalatest" %% "scalatest" % scalatestVersion % Test
   }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.8.1")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.7")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.2")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.9")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.21")


### PR DESCRIPTION
## Proposed changes

Add cross-builds for Play 2.9 and Play 3.0 on both Scala 2.13 and Scala 3. Minimize code duplication by abstracting Akka/Pekko differences and by sharing Play 2.8 source (main and test) in later versions of Play (API is apparently backward compatible). Bump the sonatype plugin and add myself as a developer. (This will be my first attempt at releasing this software, so hopefully I don't leave a trail of failed attempts.)

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/Optum/oss-template/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
